### PR TITLE
fixed missing type preventing creation of AssessmentResult

### DIFF
--- a/lib/oscal/attribute_type_hash.rb
+++ b/lib/oscal/attribute_type_hash.rb
@@ -41,6 +41,7 @@ module Oscal
     parts: AssessmentResult::PartArray,
     party_uuids: AssessmentResult::PartyUuidArray,
     props: AssessmentResult::PropArray,
+    reason: TokenDataType,
     related_controls: AssessmentResult::RelatedControls,
     related_observations: AssessmentResult::RelatedObservationArray,
     related_risks: AssessmentResult::RelatedRiskArray,


### PR DESCRIPTION
I discovered a missing entry in the attribute_type_hash that prevented creation of an AssessmentResult. Easy fix, and I hope it makes sense.
