### PR TITLE
Enable setting a custom Logger

### DIFF
--- a/lib/oscal/logger.rb
+++ b/lib/oscal/logger.rb
@@ -1,8 +1,12 @@
 module Oscal
   module ParsingLogger
     require "logger"
+    def self.logger=(value)
+      @@logger = value
+    end
+
     def get_logger
-      Logger.new($stdout)
+      @@logger ||= Logger.new($stdout)
     end
   end
 end

--- a/spec/oscal_spec.rb
+++ b/spec/oscal_spec.rb
@@ -4,4 +4,15 @@ RSpec.describe Oscal do
   it "has a version number" do
     expect(Oscal::VERSION).not_to be nil
   end
+
+  it "allows setting a new logger" do
+    logger = double(Logger)
+    Oscal::ParsingLogger.logger = logger
+
+    class LoggerTest
+      include Oscal::ParsingLogger
+    end
+
+    expect(LoggerTest.new.get_logger).to eq logger
+  end
 end


### PR DESCRIPTION
### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->

Allows setting a new logger (such as `Oscal::ParsingLogger.logger = Rails.logger`) instead of dumping everything to stdout at all times.
