### PR TITLE
Fix undefined to_json method

### DIFF
--- a/lib/oscal/assembly.rb
+++ b/lib/oscal/assembly.rb
@@ -1,6 +1,7 @@
 require_relative "parsing_functions"
 require_relative "logger"
 require_relative "metadata_block"
+require "json"
 
 module Oscal
   class MetadataBlockWrapper < Oscal::MetadataBlock
@@ -32,8 +33,8 @@ module Oscal
       end
     end
 
-    def to_json
-      to_h.to_json
+    def to_json(*args)
+      to_h.to_json(*args)
     end
 
     def to_h

--- a/lib/oscal/serializer.rb
+++ b/lib/oscal/serializer.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require "json"
 
 module Oscal
   module Serializer

--- a/spec/oscal/assessment_plan_spec.rb
+++ b/spec/oscal/assessment_plan_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+RSpec.describe Oscal::AssessmentPlan::AssessmentPlan do
+  let(:fields) do
+    {
+      uuid: "4d56d1ab-d91e-4f7a-9055-1883c4e580b8",
+      metadata: {},
+      import_ssp: { href: "./ssp.json" },
+      reviewed_controls: { control_selections: [] },
+    }
+  end
+  subject { described_class.new(fields) }
+
+  describe "#to_json" do
+    it "generates a json representation of the assessment plan" do
+      expect(subject.to_json).to be_kind_of(String)
+    end
+  end
+end

--- a/spec/oscal/assessment_plan_spec.rb
+++ b/spec/oscal/assessment_plan_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Oscal::AssessmentPlan::AssessmentPlan do
 
   describe "#to_json" do
     it "generates a json representation of the assessment plan" do
-      expect(subject.to_json).to be_kind_of(String)
+      expect(subject.to_json).to eq(JSON.generate(fields))
     end
   end
 end

--- a/spec/oscal/catalog_spec.rb
+++ b/spec/oscal/catalog_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../spec_helper"
+
 RSpec.describe Oscal::Catalog do
   let(:subject) do
     Oscal::Catalog.load_from_yaml(


### PR DESCRIPTION
### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->

I ran into some situations where `to_json` was undefined. Added in `require "json"` to ensure it's working, along with a unit test that was failing before the implementation change.