### PR TITLE
feat: bump metaschema to factory-decomposition branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem "canon"
 gem "lutaml-model", github: "lutaml/lutaml-model", branch: "main"
-gem "metaschema", github: "lutaml/metaschema"
+gem "metaschema", github: "lutaml/metaschema", branch: "feat/factory-decomposition-service-objects"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop"

--- a/README.adoc
+++ b/README.adoc
@@ -187,10 +187,12 @@ with XML and key-value (JSON/YAML) mappings.
 
 . The `metaschema` gem parses the OSCAL Metaschema XML
   (`oscal_complete_metaschema.xml`)
-. `Metaschema::ModelGenerator` creates in-memory Ruby classes from the
-  metaschema definitions
+. `Metaschema::ModelGenerator` delegates to `FieldFactory` and
+  `AssemblyFactory` to create in-memory Ruby classes
 . `Metaschema::RubySourceEmitter` serializes them to Ruby source code
 . Each class uses `Lutaml::Model::Serializable` for serialization
+. Service objects (`FieldSerializer`, `FieldDeserializer`) handle
+  SINGLETON_OR_ARRAY patterns and collapsible fields
 
 == Architecture
 


### PR DESCRIPTION
## Summary

- Update metaschema dependency to the feat/factory-decomposition-service-objects branch which includes:
  - Decomposed factories (FieldFactory, AssemblyFactory, Utils)
  - Service objects (FieldSerializer, FieldDeserializer, CollapsiblesCollapser)
  - Missing type mappings (day-time-duration, uri-reference, email-address, ip-v4-address, ip-v6-address, base64)
  - Distinct MarkupMultilineDatatype
  - JSON value key constants (RICHTEXT, prose, STRVALUE)
  - UNWRAPPED XML field handling with delegate mappings
  - moxml >= 0.1.15 (namespace_validation_mode= API)
- Update README to reflect the new factory-based generation architecture

## Dependency

Depends on lutaml/metaschema#22 being merged first.

## Test plan

- [x] All 61 oscal tests pass (0 failures, 15 pre-existing pending)
- [x] XML round-trip tests pass
- [x] No API changes -- ModelGenerator.generate_from_file interface unchanged