### PR TITLE
chore: point metaschema to main after factory merge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -187,10 +187,12 @@ with XML and key-value (JSON/YAML) mappings.
 
 . The `metaschema` gem parses the OSCAL Metaschema XML
   (`oscal_complete_metaschema.xml`)
-. `Metaschema::ModelGenerator` creates in-memory Ruby classes from the
-  metaschema definitions
+. `Metaschema::ModelGenerator` delegates to `FieldFactory` and
+  `AssemblyFactory` to create in-memory Ruby classes
 . `Metaschema::RubySourceEmitter` serializes them to Ruby source code
 . Each class uses `Lutaml::Model::Serializable` for serialization
+. Service objects (`FieldSerializer`, `FieldDeserializer`) handle
+  SINGLETON_OR_ARRAY patterns and collapsible fields
 
 == Architecture
 


### PR DESCRIPTION
## Summary

- Switch metaschema git source from feature branch back to main now that lutaml/metaschema#22 has been merged
- Resolves to metaschema 0.2.2 (factory decomposition, service objects, moxml >= 0.1.15)

## Test plan

- [x] All 61 tests pass (0 failures, 15 pre-existing pending)