### PR TITLE
fix: remove metaschema branch pin after merge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem "canon"
 gem "lutaml-model", github: "lutaml/lutaml-model", branch: "main"
-gem "metaschema", github: "lutaml/metaschema", branch: "feat/factory-decomposition-service-objects"
+gem "metaschema", github: "lutaml/metaschema"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop"


### PR DESCRIPTION
## Summary

- Remove explicit  pin from metaschema git source in Gemfile
- The branch was merged and deleted; bundler now resolves to main (metaschema 0.2.2)

## Context

PR #29 merged the feature branch reference into main, but the branch has since been deleted. This caused CI failures because bundler cached the deleted branch reference. This PR fixes the Gemfile to use the default branch (main).

## Test plan

- [x] All 61 tests pass (0 failures, 15 pre-existing pending)